### PR TITLE
Update transient jetty dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     implementation "org.apache.commons:commons-compress:1.24.0" //transient http4k-apache
     implementation "org.apache.httpcomponents:httpclient:4.5.13" //Desired transient httpclient to http4k-apache
     implementation "org.xerial.snappy:snappy-java:1.1.10.4" //Desired transient snappy to kafka-clients above
+    implementation "org.eclipse.jetty:jetty-http:9.4.53.v20231009" //Desired transient jetty for cometd
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testImplementation 'org.jetbrains.kotlin:kotlin-test'


### PR DESCRIPTION
Makes sure the resolved jetty version from cometd is a patched version to remove two known vulnerabilities